### PR TITLE
支持并行类加载

### DIFF
--- a/one-java-agent-plugin/src/main/java/com/alibaba/oneagent/plugin/PlguinClassLoader.java
+++ b/one-java-agent-plugin/src/main/java/com/alibaba/oneagent/plugin/PlguinClassLoader.java
@@ -2,40 +2,61 @@ package com.alibaba.oneagent.plugin;
 
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
- *
  * @author hengyunabc 2019-02-27
- *
  */
 public class PlguinClassLoader extends URLClassLoader {
+
+    private final ConcurrentHashMap<String, String> parallelLockMap = new ConcurrentHashMap<String, String>();
 
     public PlguinClassLoader(URL[] urls, ClassLoader parent) {
         super(urls, parent);
     }
 
     @Override
-    protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-        final Class<?> loadedClass = findLoadedClass(name);
-        if (loadedClass != null) {
-            return loadedClass;
-        }
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            final Class<?> loadedClass = findLoadedClass(name);
+            if (loadedClass != null) {
+                return loadedClass;
+            }
 
-        // 优先从parent（SystemClassLoader）里加载系统类，避免抛出ClassNotFoundException
-        if (name != null && (name.startsWith("sun.") || name.startsWith("java."))) {
+            // 优先从parent（SystemClassLoader）里加载系统类，避免抛出ClassNotFoundException
+            if (name != null && (name.startsWith("sun.") || name.startsWith("java."))) {
+                return super.loadClass(name, resolve);
+            }
+
+            try {
+                Class<?> aClass = findClass(name);
+                if (resolve) {
+                    resolveClass(aClass);
+                }
+                return aClass;
+            } catch (Exception e) {
+                // ignore
+            }
             return super.loadClass(name, resolve);
         }
+    }
 
-        try {
-            Class<?> aClass = findClass(name);
-            if (resolve) {
-                resolveClass(aClass);
+    /**
+     * return the lock of class loading
+     *
+     * @param className the class name
+     * @return the lock object
+     */
+    protected Object getClassLoadingLock(String className) {
+        Object lock = this;
+        if (parallelLockMap != null) {
+            String newLock = new String(className);
+            lock = parallelLockMap.putIfAbsent(className, newLock);
+            if (lock == null) {
+                lock = newLock;
             }
-            return aClass;
-        } catch (Exception e) {
-            // ignore
         }
-        return super.loadClass(name, resolve);
+        return lock;
     }
 
 }


### PR DESCRIPTION
由于`java.lang.ClassLoader#registerAsParallelCapable`这个方法只有jdk7+才有，但是one java agent需要支持到jdk6，所以把相关的并行类加载代码搬过来了一份。